### PR TITLE
added some more test cases

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -20,6 +20,60 @@ const GOOD_CODE = stripIndent`
 	});
 `.trim();
 
+const GOOD_CODE_CASES = [
+	stripIndent`
+	import * as functions from "firebase-functions";
+
+	export const goodHello = functions.https.onRequest((request, response) => {
+		functions.logger.info("Hello logs!", {structuredData: true});
+		response.send("Hello from Firebase!"); 
+	});
+	`,
+	stripIndent`
+	import * as functions from "firebase-functions";
+
+	export const goodHello = functions.region('europe-west1').https.onRequest((request, response) => {
+		functions.logger.info("Hello logs!", {structuredData: true});
+		response.send("Hello from Firebase!"); 
+	});
+	`,
+	stripIndent`
+	import * as functions from "firebase-functions";
+
+	export const goodHello = functions.runWith({ timeoutSeconds: 10 }).https.onRequest((request, response) => {
+		functions.logger.info("Hello logs!", {structuredData: true});
+		response.send("Hello from Firebase!"); 
+	});
+	`,
+	stripIndent`
+	import * as functions from "firebase-functions";
+
+	export const goodHello = functions.firestore.document('/orders/{orderId}')
+  	.onWrite((snapshot, context) => {
+		functions.logger.info("Hello logs!", {structuredData: true});
+		response.send("Hello from Firebase!"); 
+	});
+	`,
+	stripIndent`
+	import * as functions from "firebase-functions";
+
+	export const goodHello = functions.runWith({ timeoutSeconds: 10 }).firestore.document('/orders/{orderId}')
+  	.onWrite((snapshot, context) => {
+		functions.logger.info("Hello logs!", {structuredData: true});
+		response.send("Hello from Firebase!"); 
+	});
+	`,
+	stripIndent`
+	import * as functions from "firebase-functions";
+
+	export const goodHello = functions.runWith({ timeoutSeconds: 10 }).pubsub.schedule('every 5 minutes')
+	.onRun(async () => {
+		functions.logger.info("Hello logs!", {structuredData: true});
+		response.send("Hello from Firebase!"); 
+	});
+	`
+];
+
 const BAD_CODE = GOOD_CODE.replace('export ', '');
 
 rules.run('safe-function-exports', plugin.rules['safe-function-exports'], {


### PR DESCRIPTION
IDK exactly what needs to change to make these pass in the bad codes case.

Two things that it could be
 - there can be an arbitrary length of chained calls between `functions.` and the method to actually 'create' the function.
 - the methods to create functions are quite varied.

I know that in typescript terms any instance that is of type `functions.CloudFunction` must be exported but that's probably not the best way to think for eslint rules, I don't really know