### PR TITLE
Add devcontainer and failing test

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,18 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.224.2/containers/typescript-node/.devcontainer/base.Dockerfile
+
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+ARG VARIANT="16-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node packages
+# RUN su node -c "npm install -g <your-package-list -here>"
+
+RUN su node -c "npm install -g yarn"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.224.2/containers/typescript-node
+{
+	"name": "Node.js & TypeScript",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick a Node version: 16, 14, 12.
+		// Append -bullseye or -buster to pin to an OS version.
+		// Use -bullseye variants on local on arm64/Apple Silicon.
+		"args": { 
+			"VARIANT": "16-bullseye"
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "yarn install",
+
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node"
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -88,6 +88,15 @@ const GOOD_CODE_CASES = [
 		  console.log('Message published.', messageId);
 		});
 	`,
+	stripIndent`
+	import * as functions from "firebase-functions";
+
+	export const goodHello = functions.https.onRequest(async (request, response) => {
+		const thing = new RegExp('create using new and immediately access a field').exec(request.path);
+		functions.logger.info(thing, {structuredData: true});
+		response.send("Hello from Firebase!"); 
+	});
+`,
 ];
 
 const BAD_CODE_CASES = GOOD_CODE_CASES.map(code => code.replace('export ', ''));


### PR DESCRIPTION
Devcontainer is understood by GitHub and VSCode as a docker-based dev environment specification.

Failing test case added for "NewExpression" which currently causes an error when encountered.

"NewExpression" occurs in eslint when in a single expression an instance is created using `new` and a field on the instance is accessed.

this is OK
```
const re = new RegExp('foo')
const match = re.match('bar')
```


this is currently failing
```
const match = new RegExp('foo').match('bar')
```